### PR TITLE
Activate email on comment by default

### DIFF
--- a/db/migrate/20220328211629_activate_email_on_comment_by_default.rb
+++ b/db/migrate/20220328211629_activate_email_on_comment_by_default.rb
@@ -1,0 +1,6 @@
+class ActivateEmailOnCommentByDefault < ActiveRecord::Migration[5.1]
+  def change
+    change_column :users, :email_on_comment, :boolean, default: true
+    change_column :users, :email_on_comment_reply, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210401100648) do
+ActiveRecord::Schema.define(version: 20220328211629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1460,8 +1460,8 @@ ActiveRecord::Schema.define(version: 20210401100648) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
-    t.boolean "email_on_comment", default: false
-    t.boolean "email_on_comment_reply", default: false
+    t.boolean "email_on_comment", default: true
+    t.boolean "email_on_comment_reply", default: true
     t.string "phone_number", limit: 30
     t.string "official_position"
     t.integer "official_level", default: 0

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
     confirmed_at        { Time.current }
     date_of_birth       { 20.years.ago }
     public_activity     { true }
+    email_on_comment    { false }
+    email_on_comment_reply { false }
 
     trait :incomplete_verification do
       after :create do |user|

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -550,4 +550,30 @@ describe "Users" do
       end
     end
   end
+
+  describe "Notifications" do
+    scenario "Emails on comments are activated by default" do
+      visit new_user_registration_path
+
+      fill_in "Username", with: "CONSUL"
+      fill_in "Email", with: "user@consul.dev"
+      fill_in "Password", with: "12345678"
+      fill_in "Confirm password", with: "12345678"
+      check "By registering you accept the terms and conditions of use"
+      click_button "Register"
+
+      confirm_email
+
+      visit new_user_session_path
+
+      fill_in "Email or username", with: "CONSUL"
+      fill_in "Password", with: "12345678"
+      click_button "Enter"
+
+      click_link "My account"
+
+      expect(find_field("Notify me by email when someone comments on my proposals or debates")).to be_checked
+      expect(find_field("Notify me by email when someone replies to my comments")).to be_checked
+    end
+  end
 end


### PR DESCRIPTION
## Objectives

Activate `email_on_comment` and `email_on_comment_reply` booleans to true by default.

## Notes

Update to the existing users with:
```
User.all.each do |u|
  u.update!(email_on_comment: true, email_on_comment_reply: true)
end
```