### PR TITLE
Ignore more not real errors on Errbit

### DIFF
--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -11,10 +11,15 @@ end
 
 Airbrake.add_filter do |notice|
   ignorables = [
-    "ActiveRecord::RecordNotFound",
-    "ActionController::RoutingError",
-    "FeatureFlags::FeatureDisabled",
     "AbstractController::ActionNotFound",
+    "ActionController::RoutingError",
+    "ActionController::InvalidAuthenticityToken",
+    "ActionController::UnknownFormat",
+    "ActionDispatch::Cookies::CookieOverflow",
+    "ActionView::Template::Error",
+    "ActiveRecord::RecordNotFound",
+    "ArgumentError",
+    "FeatureFlags::FeatureDisabled",
     "SignalException"
   ]
   notice.ignore! if ignorables.include? notice[:errors].first[:type]


### PR DESCRIPTION
This client is suffering attacks that receive more than 10.000 requests in just one hour. They are not real errors, they are URLs made up. We have to reduce the workload of our error monitoring tool.
![Captura de Pantalla 2022-07-20 a las 14 08 40](https://user-images.githubusercontent.com/942995/179921388-485626f9-fb51-4b45-8862-4e087bd97142.png)
